### PR TITLE
[MCC-2117] rust-mbedtls on x86_64-pc-windows-msvc

### DIFF
--- a/mbedtls-sys/build/cmake.rs
+++ b/mbedtls-sys/build/cmake.rs
@@ -73,6 +73,18 @@ impl super::BuildConfig {
             "cargo:rustc-link-search=native={}",
             dst.to_str().expect("link-search UTF-8 error")
         );
+        // Add both Debug and Release here, because only one will actually be present, since cargo
+        // puts all this under target/debug or target/release.
+        let profile = dst.join("Debug");
+        println!(
+            "cargo:rustc-link-search=native={}",
+            profile.to_str().expect("link-search UTF-8 error")
+        );
+        let profile = dst.join("Release");
+        println!(
+            "cargo:rustc-link-search=native={}",
+            profile.to_str().expect("link-search UTF-8 error")
+        );
 
         let mut dst = cmk.build();
         dst.push("build");
@@ -81,6 +93,17 @@ impl super::BuildConfig {
         println!(
             "cargo:rustc-link-search=native={}",
             dst.to_str().expect("link-search UTF-8 error")
+        );
+
+        let profile = dst.join("Debug");
+        println!(
+            "cargo:rustc-link-search=native={}",
+            profile.to_str().expect("link-search UTF-8 error")
+        );
+        let profile = dst.join("Release");
+        println!(
+            "cargo:rustc-link-search=native={}",
+            profile.to_str().expect("link-search UTF-8 error")
         );
 
         println!("cargo:rustc-link-lib=mbedtls");

--- a/mbedtls/src/pk/mod.rs
+++ b/mbedtls/src/pk/mod.rs
@@ -35,8 +35,13 @@ pub use self::ec::{EcGroupId, ECDSA_MAX_LEN};
 #[doc(inline)]
 pub use crate::ecp::EcGroup;
 
-// SHA-256("Fortanix")[:4]
-const CUSTOM_PK_TYPE: pk_type_t = 0x8b205408 as pk_type_t;
+// Originally SHA-256("Fortanix")[:4], changed to zero-prefixed [:3] because
+// [C enums are signed](https://docs.microsoft.com/en-us/cpp/c-language/c-enumeration-declarations),
+// unless there's a value which makes them unsigned.
+//
+// This seems to force the underlying mbedtls_pk_type_t to be unsigned on Linux
+// (nightly-2020-07-01), but does not on Windows (stable-1.47.0).
+const CUSTOM_PK_TYPE: pk_type_t = 0x008b2054 as pk_type_t;
 
 define!(
     #[c_ty(pk_type_t)]
@@ -108,7 +113,7 @@ unsafe extern "C" fn free_custom_pk_ctx(p: *mut c_void) {
     Box::from_raw(p as *mut CustomPkContext);
 }
 
-extern "C" fn custom_pk_can_do(_t: u32) -> i32 {
+extern "C" fn custom_pk_can_do(_t: pk_type_t) -> i32 {
     0
 }
 

--- a/mbedtls/src/rust_printf.c
+++ b/mbedtls/src/rust_printf.c
@@ -8,6 +8,7 @@
 
 #include <stdio.h>
 #include <stdarg.h>
+#include <stdlib.h>
 
 extern void mbedtls_log(const char* msg);
 
@@ -22,7 +23,9 @@ extern int mbedtls_printf(const char *fmt, ...) {
        return -1;
 
     n++;
-    char p[n];
+    char *p = alloca(n);
+    if (p==NULL)
+        return -1;
 
     va_start(ap,fmt);
     n=vsnprintf(p,n,fmt,ap);


### PR DESCRIPTION
### Ticket
Link to ticket: https://mobilecoin.atlassian.net/browse/MCC-2117

### What has been done
- Use `alloca(3)` instead of `char p[n];`
- Add cmake profile dirs to lib search paths
- Don't add a custom enum value > 2^31 to pk_type_t, thereby coercing the enum into unsigned int
- Make the callback use the expected enum, rather than u32.

### How to test
- Install MSVC utilities.
- Install rust for `x86_64-pc-windows-msvc`.
- Install LLVM for Windows.
- Install Cmake for Windows.
- Build this

### Acceptance criteria
Windows and Linux both continue to build.