### PR TITLE
Replace core_io with genio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,12 +210,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
 name = "generic-array"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -231,6 +225,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4e26859a808ffa83a83f20c7e3c9366afea91edae637a6ac203051885882dc8"
 dependencies = [
  "void",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -316,9 +321,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.62"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba"
+checksum = "a1fa8cddc8fbbee11227ef194b5317ed014b8acbf15139bd716a18ad3fe99ec5"
 
 [[package]]
 name = "libloading"
@@ -505,6 +510,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72d5370d90f49f70bd033c3d75e87fc529fbfff9d6f7cccef07d6170079d91ea"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
 name = "proc-macro2"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -542,31 +553,43 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.4.6"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
- "fuchsia-cprng",
  "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
 ]
 
 [[package]]
-name = "rand_core"
+name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
- "rand_core 0.4.2",
+ "ppv-lite86",
+ "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.4.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "rc2"
@@ -576,15 +599,6 @@ checksum = "039209d71774c9b2ae967ffb66b73ed253b3c384c198ec0d620fdd5369c78e5e"
 dependencies = [
  "block-cipher-trait",
  "opaque-debug",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -865,6 +879,12 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "which"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,15 +197,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core_io"
-version = "0.1.20210325"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97f8932064288cc79feb4d343a399d353a6f6f001e586ece47fe518a9e8507df"
-dependencies = [
- "rustc_version",
-]
-
-[[package]]
 name = "env_logger"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -231,6 +222,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 dependencies = [
  "typenum",
+]
+
+[[package]]
+name = "genio"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4e26859a808ffa83a83f20c7e3c9366afea91edae637a6ac203051885882dc8"
+dependencies = [
+ "void",
 ]
 
 [[package]]
@@ -377,7 +377,7 @@ dependencies = [
  "cc",
  "cfg-if 1.0.0",
  "chrono",
- "core_io",
+ "genio",
  "hex",
  "hyper",
  "libc",
@@ -627,25 +627,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "rustc_version"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "safemem"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
-
-[[package]]
-name = "semver"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
 
 [[package]]
 name = "serde"
@@ -874,6 +859,12 @@ name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "which"

--- a/mbedtls/Cargo.toml
+++ b/mbedtls/Cargo.toml
@@ -19,7 +19,7 @@ keywords = ["MbedTLS","mbed","TLS","SSL","cryptography"]
 
 [dependencies]
 bitflags = "1"
-genio = { version = "0.2.1", optional = true }
+genio = { version = "0.2.1", default-features = false }
 spin = { version = "0.4.0", default-features = false, optional = true }
 serde = { version = "1.0.7", default-features = false }
 serde_derive = "1.0.7"
@@ -43,7 +43,7 @@ path = "../mbedtls-sys"
 
 [dev-dependencies]
 libc = "0.2.0"
-rand = "0.4.0"
+rand = "0.8"
 serde_cbor = "0.6"
 hex = "0.3"
 matches = "0.1.8"
@@ -55,9 +55,9 @@ cc = "1.0"
 [features]
 # Features are documented in the README
 default = ["std", "aesni", "time", "padlock"]
-std = ["mbedtls-sys-auto/std", "serde/std", "yasna"]
+std = ["mbedtls-sys-auto/std", "serde/std", "yasna", "genio/use_std"]
 debug = ["mbedtls-sys-auto/debug"]
-no_std_deps = ["genio", "spin"]
+no_std_deps = ["spin"]
 force_aesni_support = ["mbedtls-sys-auto/custom_has_support", "mbedtls-sys-auto/aes_alt", "aesni"]
 mpi_force_c_code = ["mbedtls-sys-auto/mpi_force_c_code"]
 rdrand = []

--- a/mbedtls/Cargo.toml
+++ b/mbedtls/Cargo.toml
@@ -19,7 +19,7 @@ keywords = ["MbedTLS","mbed","TLS","SSL","cryptography"]
 
 [dependencies]
 bitflags = "1"
-core_io = { version = "0.1", features = ["collections"], optional = true }
+genio = { version = "0.2.1", optional = true }
 spin = { version = "0.4.0", default-features = false, optional = true }
 serde = { version = "1.0.7", default-features = false }
 serde_derive = "1.0.7"
@@ -57,7 +57,7 @@ cc = "1.0"
 default = ["std", "aesni", "time", "padlock"]
 std = ["mbedtls-sys-auto/std", "serde/std", "yasna"]
 debug = ["mbedtls-sys-auto/debug"]
-no_std_deps = ["core_io", "spin"]
+no_std_deps = ["genio", "spin"]
 force_aesni_support = ["mbedtls-sys-auto/custom_has_support", "mbedtls-sys-auto/aes_alt", "aesni"]
 mpi_force_c_code = ["mbedtls-sys-auto/mpi_force_c_code"]
 rdrand = []

--- a/mbedtls/src/private.rs
+++ b/mbedtls/src/private.rs
@@ -87,12 +87,3 @@ pub unsafe fn cstr_to_slice<'a>(ptr: *const c_char) -> &'a [u8] {
     }
     ::core::slice::from_raw_parts(ptr as *const _, strlen(ptr))
 }
-
-#[cfg(not(feature = "std"))]
-use genio::{Error as IoError, ErrorKind as IoErrorKind};
-#[cfg(feature = "std")]
-use std::io::{Error as IoError, ErrorKind as IoErrorKind};
-
-pub fn error_to_io_error(e: Error) -> IoError {
-    IoError::new(IoErrorKind::Other, e.to_string())
-}

--- a/mbedtls/src/private.rs
+++ b/mbedtls/src/private.rs
@@ -89,7 +89,7 @@ pub unsafe fn cstr_to_slice<'a>(ptr: *const c_char) -> &'a [u8] {
 }
 
 #[cfg(not(feature = "std"))]
-use core_io::{Error as IoError, ErrorKind as IoErrorKind};
+use genio::{Error as IoError, ErrorKind as IoErrorKind};
 #[cfg(feature = "std")]
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 

--- a/mbedtls/src/ssl/context.rs
+++ b/mbedtls/src/ssl/context.rs
@@ -10,7 +10,7 @@
 use core::any::Any;
 use core::result::Result as StdResult;
 #[cfg(not(feature = "std"))]
-use core_io::{Read, Write, Result as IoResult};
+use genio::{Read, Write, Result as IoResult};
 #[cfg(feature = "std")]
 use std::io::{Read, Write, Result as IoResult};
 #[cfg(feature = "std")]
@@ -72,14 +72,14 @@ define!(
     #[repr(C)]
     struct Context {
         // config is used read-only for mutliple contexts and is immutable once configured.
-        config: Arc<Config>, 
+        config: Arc<Config>,
 
         // Must be held in heap and pointer to it as pointer is sent to MbedSSL and can't be re-allocated.
         io: Option<Box<dyn Any>>,
-        
+
         handshake_ca_cert: Option<Arc<MbedtlsList<Certificate>>>,
         handshake_crl: Option<Arc<Crl>>,
-        
+
         handshake_cert: Vec<Arc<MbedtlsList<Certificate>>>,
         handshake_pk: Vec<Arc<Pk>>,
     };
@@ -92,7 +92,7 @@ define!(
 impl Context {
     pub fn new(config: Arc<Config>) -> Self {
         let mut inner = ssl_context::default();
-        
+
         unsafe {
             ssl_init(&mut inner);
             ssl_setup(&mut inner, (&*config).into());
@@ -105,7 +105,7 @@ impl Context {
 
             handshake_ca_cert: None,
             handshake_crl: None,
-            
+
             handshake_cert: vec![],
             handshake_pk: vec![],
         }
@@ -132,7 +132,7 @@ impl Context {
             self.handshake_pk.clear();
             self.handshake_ca_cert = None;
             self.handshake_crl = None;
-            
+
             match ssl_handshake(self.into()).into_result() {
                 Err(e) => {
                     // safely end borrow of io
@@ -179,7 +179,7 @@ impl Context {
     pub fn config(&self) -> &Arc<Config> {
         &self.config
     }
-    
+
     pub fn close(&mut self) {
         unsafe {
             ssl_close_notify(self.into());
@@ -194,7 +194,7 @@ impl Context {
     pub fn io_mut(&mut self) -> Option<&mut dyn Any> {
         self.io.as_mut().map(|v| &mut **v)
     }
-    
+
     /// Return the minor number of the negotiated TLS version
     pub fn minor_version(&self) -> i32 {
         self.inner.minor_ver
@@ -226,7 +226,7 @@ impl Context {
 
 
     // Session specific functions
-    
+
     /// Return the 16-bit ciphersuite identifier.
     /// All assigned ciphersuites are listed by the IANA in
     /// https://www.iana.org/assignments/tls-parameters/tls-parameters.txt
@@ -234,7 +234,7 @@ impl Context {
         if self.inner.session.is_null() {
             return Err(Error::SslBadInputData);
         }
-        
+
         Ok(unsafe { self.inner.session.as_ref().unwrap().ciphersuite as u16 })
     }
 
@@ -306,12 +306,12 @@ impl<'ctx> HandshakeContext<'ctx> {
     pub(crate) fn init(context: &'ctx mut Context) -> Self {
         HandshakeContext { context }
     }
-    
+
     pub fn set_authmode(&mut self, am: AuthMode) -> Result<()> {
         if self.context.inner.handshake as *const _ == ::core::ptr::null() {
             return Err(Error::SslBadInputData);
         }
-        
+
         unsafe { ssl_set_hs_authmode(self.context.into(), am as i32) }
         Ok(())
     }

--- a/mbedtls/src/x509/mod.rs
+++ b/mbedtls/src/x509/mod.rs
@@ -28,7 +28,6 @@ pub use self::profile::Profile;
 use mbedtls_sys::*;
 use mbedtls_sys::types::raw_types::c_uint;
 bitflags! {
-    #[doc(inline)]
     pub struct KeyUsage: c_uint {
         const DIGITAL_SIGNATURE  = X509_KU_DIGITAL_SIGNATURE as c_uint;
         const NON_REPUDIATION    = X509_KU_NON_REPUDIATION as c_uint;
@@ -43,7 +42,6 @@ bitflags! {
 }
 
 bitflags! {
-    #[doc(inline)]
     pub struct VerifyError: u32 {
         const CERT_BAD_KEY       = X509_BADCERT_BAD_KEY as u32;
         const CERT_BAD_MD        = X509_BADCERT_BAD_MD as u32;


### PR DESCRIPTION
The `core_io` crate depends on a specific nightly version of rustc, which prevents us from being able to upgrade rust. This PR replaces the uses of `core_io` with genio.