### PR TITLE
Add way to specify what target triple to run bindgen with

### DIFF
--- a/mbedtls-sys/build/bindgen.rs
+++ b/mbedtls-sys/build/bindgen.rs
@@ -125,7 +125,7 @@ impl super::BuildConfig {
         // libclang and the current `TARGET` to parse the C files.  If the
         // `TARGET` is custom, the C stdlib headers will not exist resulting
         // in parsing errors.
-        if let Some(target) = env::var_os("RUST_MBEDTLS_BINDGEN_TARGET"){
+        if let Some(target) = env::var_os("RUST_MBEDTLS_BINDGEN_TARGET") {
             env::set_var("TARGET", target);
         }
 

--- a/mbedtls-sys/build/bindgen.rs
+++ b/mbedtls-sys/build/bindgen.rs
@@ -11,6 +11,7 @@ use bindgen;
 use std::fmt::Write as _;
 use std::fs::{self, File};
 use std::io::Write;
+use std::env;
 
 use crate::headers;
 
@@ -88,6 +89,7 @@ impl super::BuildConfig {
         }
 
         let mut cc = cc::Build::new();
+
         cc.include(&self.mbedtls_include)
         .flag(&format!(
             "-DMBEDTLS_CONFIG_FILE=\"{}\"",
@@ -114,6 +116,10 @@ impl super::BuildConfig {
                 }
                 _ => {} // skip toolchains without a configured sysroot
             };
+        }
+
+        if let Some(target) = env::var_os("RUST_MBEDTLS_BINDGEN_TARGET"){
+            env::set_var("TARGET", target);
         }
 
         let bindings = bindgen::builder()

--- a/mbedtls-sys/build/bindgen.rs
+++ b/mbedtls-sys/build/bindgen.rs
@@ -118,6 +118,13 @@ impl super::BuildConfig {
             };
         }
 
+        // In order to support being used in crates that utilize custom
+        // targets,
+        // https://docs.rust-embedded.org/embedonomicon/custom-target.html
+        // a target override is provided for bindgen usage.  Bindgen utilizes
+        // libclang and the current `TARGET` to parse the C files.  If the
+        // `TARGET` is custom, the C stdlib headers will not exist resulting
+        // in parsing errors.
         if let Some(target) = env::var_os("RUST_MBEDTLS_BINDGEN_TARGET"){
             env::set_var("TARGET", target);
         }

--- a/mbedtls-sys/build/bindgen.rs
+++ b/mbedtls-sys/build/bindgen.rs
@@ -118,13 +118,11 @@ impl super::BuildConfig {
             };
         }
 
-        // In order to support being used in crates that utilize custom
-        // targets,
-        // https://docs.rust-embedded.org/embedonomicon/custom-target.html
-        // a target override is provided for bindgen usage.  Bindgen utilizes
-        // libclang and the current `TARGET` to parse the C files.  If the
-        // `TARGET` is custom, the C stdlib headers will not exist resulting
-        // in parsing errors.
+        // Bindgen utilizes libclang and the current `TARGET` to parse the C files.
+        // When the `TARGET` is custom, we need to override it so that bindgen
+        // finds the right stdlib headers.
+        // See https://docs.rust-embedded.org/embedonomicon/custom-target.html
+        // for more details.
         if let Some(target) = env::var_os("RUST_MBEDTLS_BINDGEN_TARGET") {
             env::set_var("TARGET", target);
         }

--- a/mbedtls/src/lib.rs
+++ b/mbedtls/src/lib.rs
@@ -21,7 +21,7 @@ extern crate bitflags;
 #[macro_use]
 extern crate serde_derive;
 // required explicitly to force inclusion at link time
-#[cfg(target_env = "sgx")]
+#[cfg(all(target_vendor = "fortanix", target_env = "sgx"))]
 extern crate rs_libc;
 
 #[macro_use]


### PR DESCRIPTION
In order to utilize mbedtls with non standard target triples a way to specify the target triple for bindgen in mbedtls is provided, `RUST_MBEDTLS_BINDGEN_TARGET`