### PR TITLE
Remove `fogcore` default reviewer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,8 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 25
-  reviewers:
-    - "mobilecoinfoundation/fogcore"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
     interval: daily
   open-pull-requests-limit: 10
-  reviewers:
-    - "mobilecoinfoundation/fogcore"


### PR DESCRIPTION
We don't touch this repo often, so let's not spam the review queue.