### PR TITLE
Patch for MbedTLS PR#4978 - fixes bignum multiplication for newer versions of clang (Xcode 13/14)

### DIFF
--- a/mbedtls-sys/vendor/ChangeLog
+++ b/mbedtls-sys/vendor/ChangeLog
@@ -1,14 +1,6 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
-= mbed TLS PR #4941
-
-Bugfix
-   * Fix missing constraints on x86_64 assembly code for bignum multiplication
-     that broke some bignum operations with (at least) Clang 12.
-     Fixes #4116, #4786, #4917.
-
-= mbed TLS PR #4978
-
+= mbed TLS PR #4978 & PR #4941
 Bugfix
    * Fix missing constraints on x86_64 and aarch64 assembly code
      for bignum multiplication that broke some bignum operations with

--- a/mbedtls-sys/vendor/ChangeLog
+++ b/mbedtls-sys/vendor/ChangeLog
@@ -9,7 +9,7 @@ Bugfix
 
 = mbed TLS PR #4978
 
-	Bugfix
+Bugfix
    * Fix missing constraints on x86_64 and aarch64 assembly code
      for bignum multiplication that broke some bignum operations with
      (at least) Clang 12.

--- a/mbedtls-sys/vendor/ChangeLog
+++ b/mbedtls-sys/vendor/ChangeLog
@@ -1,5 +1,12 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS PR #4941
+
+Bugfix
+   * Fix missing constraints on x86_64 assembly code for bignum multiplication
+     that broke some bignum operations with (at least) Clang 12.
+     Fixes #4116, #4786, #4917.
+
 = mbed TLS PR #4978
 
 	Bugfix

--- a/mbedtls-sys/vendor/ChangeLog
+++ b/mbedtls-sys/vendor/ChangeLog
@@ -1,5 +1,13 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS PR #4978
+
+	Bugfix
+   * Fix missing constraints on x86_64 and aarch64 assembly code
+     for bignum multiplication that broke some bignum operations with
+     (at least) Clang 12.
+     Fixes #4116, #4786, #4917, #4962.
+
 = mbed TLS 2.26.0 branch released 2021-03-08
 
 API changes

--- a/mbedtls-sys/vendor/ChangeLog.d/muladdc-amd64-memory.txt
+++ b/mbedtls-sys/vendor/ChangeLog.d/muladdc-amd64-memory.txt
@@ -1,0 +1,4 @@
+Bugfix
+   * Fix missing constraints on x86_64 assembly code for bignum multiplication
+     that broke some bignum operations with (at least) Clang 12.
+     Fixes #4116, #4786, #4917.

--- a/mbedtls-sys/vendor/ChangeLog.d/muladdc-amd64-memory.txt
+++ b/mbedtls-sys/vendor/ChangeLog.d/muladdc-amd64-memory.txt
@@ -1,4 +1,0 @@
-Bugfix
-   * Fix missing constraints on x86_64 assembly code for bignum multiplication
-     that broke some bignum operations with (at least) Clang 12.
-     Fixes #4116, #4786, #4917.

--- a/mbedtls-sys/vendor/ChangeLog.d/muladdc-memory.txt
+++ b/mbedtls-sys/vendor/ChangeLog.d/muladdc-memory.txt
@@ -1,0 +1,5 @@
+Bugfix
+   * Fix missing constraints on x86_64 and aarch64 assembly code
+     for bignum multiplication that broke some bignum operations with
+     (at least) Clang 12.
+     Fixes #4116, #4786, #4917, #4962.

--- a/mbedtls-sys/vendor/include/mbedtls/bn_mul.h
+++ b/mbedtls-sys/vendor/include/mbedtls/bn_mul.h
@@ -189,9 +189,9 @@
         "addq   $8, %%rdi\n"
 
 #define MULADDC_STOP                        \
-        : "+c" (c), "+D" (d), "+S" (s)      \
-        : "b" (b)                           \
-        : "rax", "rdx", "r8"                \
+        : "+c" (c), "+D" (d), "+S" (s), "+m" (*(uint64_t (*)[16]) d) \
+        : "b" (b), "m" (*(const uint64_t (*)[16]) s)                 \
+        : "rax", "rdx", "r8"                                         \
     );
 
 #endif /* AMD64 */

--- a/mbedtls-sys/vendor/include/mbedtls/bn_mul.h
+++ b/mbedtls-sys/vendor/include/mbedtls/bn_mul.h
@@ -204,18 +204,18 @@
 #define MULADDC_CORE                \
         "ldr x4, [%2], #8   \n\t"   \
         "ldr x5, [%1]       \n\t"   \
-        "mul x6, x4, %3     \n\t"   \
-        "umulh x7, x4, %3   \n\t"   \
+        "mul x6, x4, %4     \n\t"   \
+        "umulh x7, x4, %4   \n\t"   \
         "adds x5, x5, x6    \n\t"   \
         "adc x7, x7, xzr    \n\t"   \
         "adds x5, x5, %0    \n\t"   \
         "adc %0, x7, xzr    \n\t"   \
         "str x5, [%1], #8   \n\t"
 
-#define MULADDC_STOP                        \
-         : "+r" (c),  "+r" (d), "+r" (s)    \
-         : "r" (b)                          \
-         : "x4", "x5", "x6", "x7", "cc"     \
+#define MULADDC_STOP                                                    \
+         : "+r" (c),  "+r" (d), "+r" (s), "+m" (*(uint64_t (*)[16]) d)  \
+         : "r" (b), "m" (*(const uint64_t (*)[16]) s)                   \
+         : "x4", "x5", "x6", "x7", "cc"                                 \
     );
 
 #endif /* Aarch64 */


### PR DESCRIPTION
### Description

Newer versions of `clang` that ships with Xcode 13 (and up) cause problems with inline-assembly code in MbedTLS.  The [original issue](https://github.com/Mbed-TLS/mbedtls/issues/4943) says this:

> Some of our inline assembly code is missing annotations telling the compiler what the assembly reads and writes (register, memory). On the platforms we test with, there are generally enough annotations to get correct code, but we're at the mercy of a new compiler version that optimizes better. This happened on x86_64 with Clang 12 and the bignum multiplication code (https://github.com/Mbed-TLS/mbedtls/issues/4116, https://github.com/Mbed-TLS/mbedtls/issues/4786, https://github.com/Mbed-TLS/mbedtls/issues/4917) ...

My PR adds the code fix for 2.x that came in this [MbedTLS PR 4978](https://github.com/Mbed-TLS/mbedtls/pull/4978/files). 

### Additional Notes

MobileCoin's [IAS Report Verifier](https://github.com/mobilecoinfoundation/mobilecoin/blob/master/attest/verifier/src/ias.rs#L140) uses this code to verify the certificate chain. The bug causes this [line](https://github.com/mobilecoinfoundation/mobilecoin/blob/master/attest/verifier/src/ias.rs#L140) to fail with an `  
RsaVerifyFailed = ERR_RSA_VERIFY_FAILED` MbedTLS error which stops the Attestation process. On Swift this shows up as a `ReportVerification(BadSignature)` error. 

