### PR TITLE
modify license expressions in cargo toml

### DIFF
--- a/mbedtls-sys/Cargo.toml
+++ b/mbedtls-sys/Cargo.toml
@@ -3,7 +3,7 @@ name = "mbedtls-sys-auto"
 version = "2.26.1"
 authors = ["Jethro Beekman <jethro@fortanix.com>"]
 build = "build/build.rs"
-license = "Apache-2.0/GPL-2.0-or-later"
+license = "Apache-2.0 OR GPL-2.0-or-later"
 description = """
 Rust bindings for MbedTLS.
 

--- a/mbedtls-sys/Cargo.toml
+++ b/mbedtls-sys/Cargo.toml
@@ -3,7 +3,7 @@ name = "mbedtls-sys-auto"
 version = "2.26.1"
 authors = ["Jethro Beekman <jethro@fortanix.com>"]
 build = "build/build.rs"
-license = "Apache-2.0/GPL-2.0+"
+license = "Apache-2.0/GPL-2.0-or-later"
 description = """
 Rust bindings for MbedTLS.
 

--- a/mbedtls/Cargo.toml
+++ b/mbedtls/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.8.1"
 authors = ["Jethro Beekman <jethro@fortanix.com>"]
 build = "build.rs"
 edition = "2018"
-license = "Apache-2.0/GPL-2.0+"
+license = "Apache-2.0/GPL-2.0-or-later"
 description = """
 Idiomatic Rust wrapper for MbedTLS, allowing you to use MbedTLS with only safe
 code while being able to use such great Rust features like error handling and

--- a/mbedtls/Cargo.toml
+++ b/mbedtls/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.8.1"
 authors = ["Jethro Beekman <jethro@fortanix.com>"]
 build = "build.rs"
 edition = "2018"
-license = "Apache-2.0/GPL-2.0-or-later"
+license = "Apache-2.0 OR GPL-2.0-or-later"
 description = """
 Idiomatic Rust wrapper for MbedTLS, allowing you to use MbedTLS with only safe
 code while being able to use such great Rust features like error handling and


### PR DESCRIPTION
cargo deny doesn't seem to understand `GPL-2.0+` right now, see https://github.com/EmbarkStudios/cargo-deny/issues/498