### PR TITLE
Hold rust cmake back at 0.1.45 for android builds

### DIFF
--- a/mbedtls-sys/Cargo.toml
+++ b/mbedtls-sys/Cargo.toml
@@ -28,7 +28,7 @@ libc = { version = "0.2.139" }
 
 [build-dependencies]
 bindgen = "0.64.0"
-cmake = "0.1.49"
+cmake = "0.1.45"
 cc = "1.0.79"
 lazy_static = "1.4"
 syn = { version = "2.0.13", features = ["full", "visit"] }

--- a/mbedtls-sys/vendor/library/bignum.c
+++ b/mbedtls-sys/vendor/library/bignum.c
@@ -1550,7 +1550,7 @@ __attribute__ ((noinline))
 #endif
 void mpi_mul_hlp( size_t i, mbedtls_mpi_uint *s, mbedtls_mpi_uint *d, mbedtls_mpi_uint b )
 {
-    mbedtls_mpi_uint c = 0;
+    mbedtls_mpi_uint c = 0, t = 0;
 
 #if defined(MULADDC_HUIT)
     for( ; i >= 8; i -= 8 )
@@ -1600,6 +1600,8 @@ void mpi_mul_hlp( size_t i, mbedtls_mpi_uint *s, mbedtls_mpi_uint *d, mbedtls_mp
         MULADDC_STOP
     }
 #endif /* MULADDC_HUIT */
+
+    t++;
 
     do {
         *d += c; c = ( *d < c ); d++;


### PR DESCRIPTION
Add back missing variables for i686 builds.