### PR TITLE
set_hostname can be used with no_std

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-04-29
+          toolchain: nightly-2023-01-22
           target: x86_64-unknown-linux-gnu
           override: true
           profile: minimal
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-04-29
+          toolchain: nightly-2023-01-22
           target: x86_64-unknown-linux-gnu
           override: true
           profile: minimal

--- a/mbedtls/src/ssl/context.rs
+++ b/mbedtls/src/ssl/context.rs
@@ -6,6 +6,7 @@
  * option. This file may not be copied, modified, or distributed except
  * according to those terms. */
 
+extern crate alloc;
 
 use core::any::Any;
 use core::result::Result as StdResult;
@@ -144,18 +145,9 @@ impl Context {
         }
     }
 
-    #[cfg(not(feature = "std"))]
-    fn set_hostname(&mut self, hostname: Option<&str>) -> Result<()> {
-        match hostname {
-            Some(_) => Err(Error::SslBadInputData),
-            None => Ok(()),
-        }
-    }
-
-    #[cfg(feature = "std")]
     fn set_hostname(&mut self, hostname: Option<&str>) -> Result<()> {
         if let Some(s) = hostname {
-            let cstr = ::std::ffi::CString::new(s).map_err(|_| Error::SslBadInputData)?;
+            let cstr = alloc::ffi::CString::new(s).map_err(|_| Error::SslBadInputData)?;
             unsafe {
                 ssl_set_hostname(self.into(), cstr.as_ptr())
                     .into_result()

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,2 @@
-nightly-2022-04-29
+[toolchain]
+channel = "nightly-2023-01-22"


### PR DESCRIPTION
This enables SNI to work properly when building a TLS client using `mbedtls`.