### PR TITLE
Disable warnings as errors

### DIFF
--- a/mbedtls-sys/build/cmake.rs
+++ b/mbedtls-sys/build/cmake.rs
@@ -17,6 +17,7 @@ impl super::BuildConfig {
         ))
         .define("ENABLE_PROGRAMS", "OFF")
         .define("ENABLE_TESTING", "OFF")
+        .define("MBEDTLS_FATAL_WARNINGS", "OFF")
         .build_target("lib");
         for cflag in &self.cflags {
             cmk.cflag(cflag);


### PR DESCRIPTION
In particular for apple arm builds some variables show up as unused. These unused warnings result in compilation errors. Disabling all warnings as errors.