### PR TITLE
Bump the rust toolchain to match MobileCoin repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2023-01-22
+          toolchain: nightly-2023-10-01
           target: x86_64-unknown-linux-gnu
           override: true
           profile: minimal
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2023-01-22
+          toolchain: nightly-2023-10-01
           target: x86_64-unknown-linux-gnu
           override: true
           profile: minimal

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2023-01-22"
+channel = "nightly-2023-10-01"


### PR DESCRIPTION
This fixes CI not working due to cargo grabbing the newest version of all the crates and one of the crates no longer working with the specified rust version.