### PR TITLE
try fixing a cast issue on recent android build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2023-10-01
+          toolchain: nightly-2024-06-17
           target: x86_64-unknown-linux-gnu
           override: true
           profile: minimal
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2023-10-01
+          toolchain: nightly-2024-06-17
           target: x86_64-unknown-linux-gnu
           override: true
           profile: minimal

--- a/mbedtls/src/ssl/context.rs
+++ b/mbedtls/src/ssl/context.rs
@@ -14,7 +14,7 @@ use genio::{Read, Write};
 #[cfg(feature = "std")]
 use std::sync::Arc;
 
-use mbedtls_sys::types::raw_types::{c_int, c_uchar, c_void};
+use mbedtls_sys::types::raw_types::{c_int, c_char, c_uchar, c_void};
 use mbedtls_sys::types::size_t;
 use mbedtls_sys::*;
 
@@ -149,7 +149,7 @@ impl Context {
         if let Some(s) = hostname {
             let cstr = alloc::ffi::CString::new(s).map_err(|_| Error::SslBadInputData)?;
             unsafe {
-                ssl_set_hostname(self.into(), cstr.as_ptr())
+                ssl_set_hostname(self.into(), cstr.as_ptr() as *const c_char)
                     .into_result()
                     .map(|_| ())
             }

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2023-10-01"
+channel = "nightly-2024-06-17"


### PR DESCRIPTION
When working on https://github.com/mobilecoinofficial/android-bindings/pull/15, @bcgreijnlautier and I ran into an issue where the i686 build had the Rust compiler think a `char` is `i8`, and `mbedtls` think it's a `u8`. This solves it for all platforms.